### PR TITLE
Feat/phpstan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 - Integrated **PHPStan** for static code analysis.
 
 ### Changed
-- Ran PHPStan and made several adjustments to align with static analysis best practices.
+- Executed PHPStan and made several improvements to comply with static analysis standards and Laravel best practices.
 
 ### Fixed
-- Updated method signature of `getAllWordsWithTranslations()` to resolve deprecated parameter order warning in PHP 8+.
+- Refactored the method signature of `getAllWordsWithTranslations()` in the `WordRepository`:
+  - Removed the default value from the `$perPage` parameter to avoid deprecated parameter order issues in PHP 8+.
 - Improved the `translations` relationship in the `Word` model:
   - Added missing import for the `Translation` model.
-  - Added PHPDoc annotations to enhance Larastan support and IDE autocompletion.
+  - Added PHPDoc annotations to improve Larastan compatibility and IDE autocompletion.
 
 ## [v1.12.2] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and adheres to the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
 
 ---
-## [v1.13.0] - 2025-07-13
+## [v1.12.3] - 2025-07-14
 
 ### Added
 - Integrated **PHPStan** for static code analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
   - Explicitly typed the `$translation` variable to help PHPStan infer the correct model and avoid false positives.
 - Fixed return type in `WordCollection::toArray()`:
   - Converted the collection to a plain array using `$this->collection->all()` to satisfy PHPStan's type expectations.
+- Updated PHPDoc types of `$fillable` and `$hidden` in `User` model to use `list<string>` to comply with Laravel base model definition and fix PHPStan covariance warnings.
 
 ## [v1.12.2] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 ### Changed
 - Executed PHPStan and made several improvements to comply with static analysis standards and Laravel best practices.
+- **Updated** `docs/guides/setup.md`:
+  - Added `php artisan jwt:secret` setup step.
+  - Noted the required `.env` variable `JWT_SECRET=`.
 
 ### Fixed
 - Refactored the method signature of `getAllWordsWithTranslations()` in the `WordRepository`:
@@ -24,6 +27,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 - Fixed return type in `WordCollection::toArray()`:
   - Converted the collection to a plain array using `$this->collection->all()` to satisfy PHPStan's type expectations.
 - Updated PHPDoc types of `$fillable` and `$hidden` in `User` model to use `list<string>` to comply with Laravel base model definition and fix PHPStan covariance warnings.
+- **Fixed** `docs/api/README.md`:
+  - Clarified authentication endpoints
 
 ## [v1.12.2] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 - Improved the `translations` relationship in the `Word` model:
   - Added missing import for the `Translation` model.
   - Added PHPDoc annotations to improve Larastan compatibility and IDE autocompletion.
+- Resolved property access warnings in `WordResource`:
+  - Added `@mixin \App\Models\Word` annotation to inform static analyzers of the underlying model.
+  - Explicitly typed the `$translation` variable to help PHPStan infer the correct model and avoid false positives.
 
 ## [v1.12.2] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 - Resolved property access warnings in `WordResource`:
   - Added `@mixin \App\Models\Word` annotation to inform static analyzers of the underlying model.
   - Explicitly typed the `$translation` variable to help PHPStan infer the correct model and avoid false positives.
+- Fixed return type in `WordCollection::toArray()`:
+  - Converted the collection to a plain array using `$this->collection->all()` to satisfy PHPStan's type expectations.
 
 ## [v1.12.2] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and adheres to the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
 
 ---
+## [v1.13.0] - 2025-07-13
+
+### Added
+- Integrated **PHPStan** for static code analysis.
+
+### Changed
+- Ran PHPStan and made several adjustments to align with static analysis best practices.
+
+### Fixed
+- Updated method signature of `getAllWordsWithTranslations()` to resolve deprecated parameter order warning in PHP 8+.
+- Improved the `translations` relationship in the `Word` model:
+  - Added missing import for the `Translation` model.
+  - Added PHPDoc annotations to enhance Larastan support and IDE autocompletion.
 
 ## [v1.12.2] - 2025-07-13
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWordTranslatorAPI
 
-[![Version](https://img.shields.io/badge/Version-1.12.2-blue.svg)](https://github.com/proyectosbeta/TechWordTranslatorAPI)
+[![Version](https://img.shields.io/badge/Version-1.12.3-blue.svg)](https://github.com/proyectosbeta/TechWordTranslatorAPI)
 [![License](https://img.shields.io/badge/license-GPL%20v3-blue.svg)](LICENSE)
 [![PHP Version](https://img.shields.io/badge/PHP-8.4.10-blue.svg)](https://www.php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.20.0-green.svg)](https://laravel.com/)

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,4 @@
 - Add Opcache
 - Monitor (Grafana)
 - Add swagger (dev documentation)
+- Add php cs fix (config)

--- a/app/Http/Resources/WordCollection.php
+++ b/app/Http/Resources/WordCollection.php
@@ -25,7 +25,7 @@ class WordCollection extends ResourceCollection
     public function toArray($request): array
     {
         return [
-            'data' => $this->collection,
+            'data' => $this->collection->all(),
         ];
     }
 

--- a/app/Http/Resources/WordResource.php
+++ b/app/Http/Resources/WordResource.php
@@ -4,10 +4,14 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @mixin \App\Models\Word
+ */
 class WordResource extends JsonResource
 {
     public function toArray($request): array
     {
+        /** @var \App\Models\Translation|null $translation */
         $translation = $this->translations->first();
 
         return [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,7 +16,7 @@ class User extends Authenticatable implements JWTSubject
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $fillable = [
         'name',
@@ -27,7 +27,7 @@ class User extends Authenticatable implements JWTSubject
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $hidden = [
         'password',

--- a/app/Models/Word.php
+++ b/app/Models/Word.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Translation;
 
 class Word extends Model
 {
@@ -20,7 +21,12 @@ class Word extends Model
         'english_word',
     ];
 
-    public function translations()
+    /**
+     * Get the translations for the word.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function translations(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(Translation::class);
     }

--- a/app/Repositories/WordRepository.php
+++ b/app/Repositories/WordRepository.php
@@ -10,7 +10,7 @@ class WordRepository implements WordRepositoryInterface
 {
     public function __construct(protected Word $model){}
 
-    public function getAllWordsWithTranslations(int $perPage = 15, ?string $cursor): CursorPaginator
+    public function getAllWordsWithTranslations(int $perPage, ?string $cursor): CursorPaginator
     {
         return $this->model
           ->with('translations:id,word_id,spanish_word,german_word')

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "laravel/sail": "1.41.1",
         "mockery/mockery": "1.6.12",
         "nunomaduro/collision": "v8.8.2",
+        "nunomaduro/larastan": "3.5",
         "php-cs-fixer/shim": "v3.75.0",
         "phpunit/phpunit": "^11.5.27",
         "rogervila/php-sonarqube-scanner": "1.1",
@@ -53,7 +54,8 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "phpstan": "vendor/bin/phpstan analyse --memory-limit=512M"
     },
     "extra": {
         "laravel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "496b6b84bd1b55f277eb5098f05ee8dd",
+    "content-hash": "e8e32fc96ca302ba81909a3a02aa87cf",
     "packages": [
         {
             "name": "brick/math",
@@ -6673,6 +6673,47 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "947083e2dca211a6f12fb1beb67a01e387de9b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/947083e2dca211a6f12fb1beb67a01e387de9b62",
+                "reference": "947083e2dca211a6f12fb1beb67a01e387de9b62",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.6"
+            },
+            "time": "2025-03-17T16:59:46+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.11.0",
             "source": {
@@ -7044,6 +7085,96 @@
             "time": "2025-06-25T02:12:12+00:00"
         },
         {
+            "name": "nunomaduro/larastan",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "e8ccd73008487ba91da9877b373f8c447743f1ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/e8ccd73008487ba91da9877b373f8c447743f1ce",
+                "reference": "e8ccd73008487ba91da9877b373f8c447743f1ce",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.6.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1",
+                "illuminate/container": "^11.44.2 || ^12.4.1",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1",
+                "illuminate/database": "^11.44.2 || ^12.4.1",
+                "illuminate/http": "^11.44.2 || ^12.4.1",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1",
+                "illuminate/support": "^11.44.2 || ^12.4.1",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.1.11"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "laravel/framework": "^11.44.2 || ^12.7.2",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "abandoned": "larastan/larastan",
+            "time": "2025-06-19T22:41:50+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -7212,6 +7343,64 @@
                 "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.75.0"
             },
             "time": "2025-03-31T18:45:02+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-21T20:55:28+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,8 @@ https://your-domain.com/api
 
 ## Authentication
 
-- **Login**: `POST /auth/login`  
+- **Register**: `POST /user/register`  
+- **Login**: `POST /user/login`
 - **Refresh token**: `POST /auth/refresh`  
 - Returns JWT in JSON payload. Send as `Authorization: Bearer <token>`.
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -24,7 +24,10 @@ This guide will help you setup the TechWordTranslatorAPI locally.
    ```bash
    cp .env.example .env
    php artisan key:generate
+   php artisan jwt:secret
    ```
+   
+   > This will generate and set the JWT_SECRET in your .env file, required for authentication.
 
 3. **Install PHP dependencies**  
    ```bash

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,12 +2,11 @@ includes:
   - vendor/nunomaduro/larastan/extension.neon
 
 parameters:
-  level: 0
+  level: 2
   paths:
     - app
     - database
     - routes
-    - tests
   checkUnionTypes: true
   checkExplicitMixed: true
   inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,8 @@ parameters:
   paths:
     - app
     - database
+    - routes
+    - tests
   checkUnionTypes: true
   checkExplicitMixed: true
   inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+includes:
+  - vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+  level: 0
+  paths:
+    - app
+    - database
+  checkUnionTypes: true
+  checkExplicitMixed: true
+  inferPrivatePropertyTypeFromConstructor: true
+  checkDynamicProperties: true
+  ignoreErrors:
+    # - identifier: missingType.iterableValue
+    # - identifier: missingType.generics

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ Route::prefix('v1')
             ->group(function () {
                 Route::post('register', [AuthController::class, 'register'])->name('register');
                 Route::post('login',    [AuthController::class, 'login'])->name('login');
-                Route::get('/',         [AuthController::class, 'getUser'])->name('getUser');
+                #Route::get('/',         [AuthController::class, 'getUser'])->name('getUser');
             });
 
         Route::middleware('jwt.verify')->group(function () {


### PR DESCRIPTION
### Added
- Integrated **PHPStan** for static code analysis.

### Changed
- Executed PHPStan and made several improvements to comply with static analysis standards and Laravel best practices.
- **Updated** `docs/guides/setup.md`:
  - Added `php artisan jwt:secret` setup step.
  - Noted the required `.env` variable `JWT_SECRET=`.

### Fixed
- Refactored the method signature of `getAllWordsWithTranslations()` in the `WordRepository`:
  - Removed the default value from the `$perPage` parameter to avoid deprecated parameter order issues in PHP 8+.
- Improved the `translations` relationship in the `Word` model:
  - Added missing import for the `Translation` model.
  - Added PHPDoc annotations to improve Larastan compatibility and IDE autocompletion.
- Resolved property access warnings in `WordResource`:
  - Added `@mixin \App\Models\Word` annotation to inform static analyzers of the underlying model.
  - Explicitly typed the `$translation` variable to help PHPStan infer the correct model and avoid false positives.
- Fixed return type in `WordCollection::toArray()`:
  - Converted the collection to a plain array using `$this->collection->all()` to satisfy PHPStan's type expectations.
- Updated PHPDoc types of `$fillable` and `$hidden` in `User` model to use `list<string>` to comply with Laravel base model definition and fix PHPStan covariance warnings.
- **Fixed** `docs/api/README.md`:
  - Clarified authentication endpoints