### PR TITLE
fix(deps): upgrade webonyx/graphql-php 15.31.4 → 15.31.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 ---
 
+## [v1.18.1] - 2026-04-15
+
+### Security
+
+- **deps**: Upgrade `webonyx/graphql-php` 15.31.4 → 15.31.5 — patches medium-severity DoS via quadratic complexity in `OverlappingFieldsCanBeMerged` validation (GHSA-68jq-c3rv-pcrr)
+
+---
+
 ## [v1.18.0] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 ### Security
 
-- **deps**: Upgrade `webonyx/graphql-php` 15.31.4 → 15.31.5 — patches medium-severity DoS via quadratic complexity in `OverlappingFieldsCanBeMerged` validation (GHSA-68jq-c3rv-pcrr)
+- **graphql**: Upgraded `webonyx/graphql-php` 15.31.4 → 15.31.5 — patches [GHSA-68jq-c3rv-pcrr](https://github.com/advisories/GHSA-68jq-c3rv-pcrr), a medium-severity Denial of Service caused by quadratic algorithmic complexity in the `OverlappingFieldsCanBeMerged` validation rule; a crafted GraphQL query could trigger excessive CPU usage
+- **npm**: Upgraded `follow-redirects` to 1.16.0 — patches [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653), a moderate-severity information disclosure where custom `Authorization` headers were leaked to cross-domain redirect targets
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — TechWordTranslatorAPI
 
 Reference guide for Claude Code when working on this project.
-Last updated: 2026-04-09 (Vite 8 security upgrade)
+Last updated: 2026-04-15 (webonyx/graphql-php DoS patch)
 
 ---
 
@@ -10,7 +10,7 @@ Last updated: 2026-04-09 (Vite 8 security upgrade)
 **TechWordTranslatorAPI** is a RESTful API (+ GraphQL) for translating IT-world terms between English, Spanish, and German (extensible to any ISO 639-1 language). Built with Laravel 12, PHP 8.4, JWT authentication, and Redis cache.
 
 - **Repository:** github.com/josego85/TechWordTranslatorAPI
-- **Current version:** 1.18.0
+- **Current version:** 1.18.1
 - **License:** GPL-3.0-or-later
 - **Main branch:** `main`
 
@@ -579,6 +579,10 @@ Tests:        Class + Test             (WordApiTest, WordServiceTest)
 - Opcache configuration
 - Grafana monitoring
 - Swagger/OpenAPI documentation
+
+### Completed (2026-04-15)
+
+- ✅ Security patch — `webonyx/graphql-php` 15.31.4 → 15.31.5 (medium DoS via quadratic complexity in `OverlappingFieldsCanBeMerged` validation — GHSA-68jq-c3rv-pcrr); vendor updated inside Docker; `composer audit` clean; 211 tests, 598 assertions green
 
 ### Completed (2026-04-04)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWordTranslatorAPI
 
-[![Version](https://img.shields.io/badge/Version-1.18.0-blue.svg)](https://github.com/josego85/TechWordTranslatorAPI)
+[![Version](https://img.shields.io/badge/Version-1.18.1-blue.svg)](https://github.com/josego85/TechWordTranslatorAPI)
 [![License](https://img.shields.io/badge/license-GPL%20v3-blue.svg)](LICENSE)
 [![PHP Version](https://img.shields.io/badge/PHP-8.4.16-blue.svg)](https://www.php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.55.1-green.svg)](https://laravel.com/)

--- a/composer.lock
+++ b/composer.lock
@@ -7027,16 +7027,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.31.4",
+            "version": "v15.31.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "8868e83562d9178e316097489440158b487be5fd"
+                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/8868e83562d9178e316097489440158b487be5fd",
-                "reference": "8868e83562d9178e316097489440158b487be5fd",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/089c4ef7e112df85788cfe06596278a8f99f4aa9",
+                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9",
                 "shasum": ""
             },
             "require": {
@@ -7065,7 +7065,7 @@
                 "symfony/polyfill-php81": "^1.23",
                 "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
                 "thecodingmachine/safe": "^1.3 || ^2 || ^3",
-                "ticketswap/phpstan-error-formatter": "1.2.6"
+                "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
                 "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
@@ -7090,7 +7090,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.4"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.5"
             },
             "funding": [
                 {
@@ -7102,7 +7102,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-02T07:20:06+00:00"
+            "time": "2026-04-11T18:06:15+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,8 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "TechWordTranslatorAPI",
+            "license": "GPL-3.0-or-later",
             "devDependencies": {
                 "axios": "1.15.0",
                 "laravel-vite-plugin": "3.0.1",
@@ -472,9 +474,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -482,7 +484,6 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },


### PR DESCRIPTION
### Security

- **graphql**: Upgraded `webonyx/graphql-php` 15.31.4 → 15.31.5 — patches [GHSA-68jq-c3rv-pcrr](https://github.com/advisories/GHSA-68jq-c3rv-pcrr), a medium-severity Denial of Service caused by quadratic algorithmic complexity in the `OverlappingFieldsCanBeMerged` validation rule; a crafted GraphQL query could trigger excessive CPU usage
- **npm**: Upgraded `follow-redirects` to 1.16.0 — patches [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653), a moderate-severity information disclosure where custom `Authorization` headers were leaked to cross-domain redirect targets