### PR TITLE
fix(deps): security patch v1.18.2 — graphql-php 15.32.3, axios 1.16.0…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 ---
 
+## [v1.18.2] - 2026-05-09
+
+### Security
+
+- **graphql**: Upgraded `webonyx/graphql-php` 15.31.5 → 15.32.3 — patches two high-severity DoS vulnerabilities:
+  - Quadratic validation cost in `OverlappingFieldsCanBeMerged` via inline fragments — a crafted GraphQL document using inline fragment spreads could trigger O(n²) validation time before the query complexity limit is applied ([GHSA-fc86-6rv6-2jpm](https://github.com/advisories/GHSA-fc86-6rv6-2jpm)); fixed in `>=15.32.2`
+  - Unbounded recursion in the parser — a crafted deeply nested input causes a stack overflow and kills the PHP-FPM worker ([GHSA-r7cg-qjjm-xhqq](https://github.com/advisories/GHSA-r7cg-qjjm-xhqq)); fixed in `>=15.32.3`
+- **npm**: Upgraded `axios` 1.15.0 → 1.16.0 — patches 13 high-severity CVEs across four vulnerability classes:
+  - **Prototype pollution gadgets** — authentication bypass via `validateStatus` merge strategy ([GHSA-w9j2-pvgh-6h63](https://github.com/advisories/GHSA-w9j2-pvgh-6h63)), invisible JSON response tampering via `parseReviver` ([GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23)), credential injection and request hijacking via HTTP adapter read-side gadgets ([GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj)), header injection ([GHSA-6chq-wfr3-2hj9](https://github.com/advisories/GHSA-6chq-wfr3-2hj9)), XSRF token cross-origin leakage via `withXSRFToken` boolean coercion ([GHSA-xx6v-rp6x-q39c](https://github.com/advisories/GHSA-xx6v-rp6x-q39c)), response tampering / data exfiltration / request hijacking gadget suite ([GHSA-pf86-5x62-jrwf](https://github.com/advisories/GHSA-pf86-5x62-jrwf))
+  - **Injection** — null byte injection via reverse-encoding in `AxiosURLSearchParams` ([GHSA-xhjh-pmcv-23jw](https://github.com/advisories/GHSA-xhjh-pmcv-23jw)), CRLF injection in `multipart/form-data` body via unsanitized `blob.type` in `formDataToStream` ([GHSA-445q-vr5w-6q77](https://github.com/advisories/GHSA-445q-vr5w-6q77))
+  - **SSRF / proxy bypass** — incomplete `NO_PROXY` fix bypassed via RFC 1122 loopback subnet `127.0.0.0/8` ([GHSA-pmwg-cvhr-8vh7](https://github.com/advisories/GHSA-pmwg-cvhr-8vh7)), `no_proxy` bypass via IP alias allowing SSRF ([GHSA-m7pr-hjqh-92cm](https://github.com/advisories/GHSA-m7pr-hjqh-92cm))
+  - **Limit bypass / DoS** — HTTP adapter streamed uploads bypass `maxBodyLength` when `maxRedirects: 0` ([GHSA-5c9x-8gcm-mpgx](https://github.com/advisories/GHSA-5c9x-8gcm-mpgx)), streamed responses bypass `maxContentLength` ([GHSA-vf2m-468p-8v99](https://github.com/advisories/GHSA-vf2m-468p-8v99)), unbounded recursion in `toFormData` causes DoS via deeply nested request data ([GHSA-62hf-57xw-28j9](https://github.com/advisories/GHSA-62hf-57xw-28j9))
+- **npm**: Upgraded `postcss` 8.5.9 → 8.5.14 (transitive dependency via `vite`) — patches [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93), a moderate-severity XSS where unescaped `</style>` tags in CSS stringify output could allow script injection in downstream HTML consumers
+
+---
+
 ## [v1.18.1] - 2026-04-15
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — TechWordTranslatorAPI
 
 Reference guide for Claude Code when working on this project.
-Last updated: 2026-04-15 (webonyx/graphql-php DoS patch)
+Last updated: 2026-05-09 (v1.18.2 security patch — graphql-php 15.32.3, axios 1.16.0, postcss 8.5.14)
 
 ---
 
@@ -10,7 +10,7 @@ Last updated: 2026-04-15 (webonyx/graphql-php DoS patch)
 **TechWordTranslatorAPI** is a RESTful API (+ GraphQL) for translating IT-world terms between English, Spanish, and German (extensible to any ISO 639-1 language). Built with Laravel 12, PHP 8.4, JWT authentication, and Redis cache.
 
 - **Repository:** github.com/josego85/TechWordTranslatorAPI
-- **Current version:** 1.18.1
+- **Current version:** 1.18.2
 - **License:** GPL-3.0-or-later
 - **Main branch:** `main`
 
@@ -579,6 +579,10 @@ Tests:        Class + Test             (WordApiTest, WordServiceTest)
 - Opcache configuration
 - Grafana monitoring
 - Swagger/OpenAPI documentation
+
+### Completed (2026-05-09)
+
+- ✅ Security patch v1.18.2 — `webonyx/graphql-php` 15.31.5 → 15.32.3 (2 high DoS CVEs: GHSA-fc86-6rv6-2jpm inline-fragment quadratic validation, GHSA-r7cg-qjjm-xhqq parser stack overflow); `axios` 1.15.0 → 1.16.0 (13 high CVEs — prototype pollution, injection, SSRF, limit bypass); `postcss` 8.5.9 → 8.5.14 via vite (GHSA-qx2v-qp2m-jg93 XSS); `composer audit` + `npm audit` clean; 211 tests, 598 assertions green
 
 ### Completed (2026-04-15)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWordTranslatorAPI
 
-[![Version](https://img.shields.io/badge/Version-1.18.1-blue.svg)](https://github.com/josego85/TechWordTranslatorAPI)
+[![Version](https://img.shields.io/badge/Version-1.18.2-blue.svg)](https://github.com/josego85/TechWordTranslatorAPI)
 [![License](https://img.shields.io/badge/license-GPL%20v3-blue.svg)](LICENSE)
 [![PHP Version](https://img.shields.io/badge/PHP-8.4.16-blue.svg)](https://www.php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.55.1-green.svg)](https://laravel.com/)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php-open-source-saver/jwt-auth": "2.9.0",
         "predis/predis": "3.4.2",
         "prism-php/prism": "0.100.1",
-        "spatie/laravel-csp": "3.23.0"
+        "spatie/laravel-csp": "3.23.0",
+        "webonyx/graphql-php": "15.32.3"
     },
     "require-dev": {
         "driftingly/rector-laravel": "2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0731309392a45030d1c8e582578a5aa",
+    "content-hash": "e6930f9dc245e296d069a99009c92e12",
     "packages": [
         {
             "name": "brick/math",
@@ -7027,16 +7027,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.31.5",
+            "version": "v15.32.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9"
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/089c4ef7e112df85788cfe06596278a8f99f4aa9",
-                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
                 "shasum": ""
             },
             "require": {
@@ -7045,16 +7045,16 @@
                 "php": "^7.4 || ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2.6",
-                "amphp/http-server": "^2.1",
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.94.2",
+                "friendsofphp/php-cs-fixer": "3.95.1",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan": "2.1.51",
                 "phpstan/phpstan-phpunit": "2.0.16",
                 "phpstan/phpstan-strict-rules": "2.0.10",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
@@ -7068,6 +7068,7 @@
                 "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
                 "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
                 "psr/http-message": "To use standard GraphQL server",
                 "react/promise": "To leverage async resolving on React PHP platform"
@@ -7090,7 +7091,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.5"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
             },
             "funding": [
                 {
@@ -7102,7 +7103,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-11T18:06:15+00:00"
+            "time": "2026-04-24T13:49:35+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6930f9dc245e296d069a99009c92e12",
+    "content-hash": "a8df0302466cf99b73f76ddddae2d4fd",
     "packages": [
         {
             "name": "brick/math",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-    "name": "TechWordTranslatorAPI",
+    "name": "techwordtranslatorapi",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "TechWordTranslatorAPI",
+            "name": "techwordtranslatorapi",
             "license": "GPL-3.0-or-later",
             "devDependencies": {
-                "axios": "1.15.0",
+                "axios": "1.16.0",
                 "laravel-vite-plugin": "3.0.1",
                 "vite": "8.0.8"
             }
@@ -336,12 +336,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -968,9 +969,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -986,6 +987,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "techwordtranslatorapi",
     "private": true,
     "type": "module",
     "license": "GPL-3.0-or-later",
@@ -7,7 +8,7 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "laravel-vite-plugin": "3.0.1",
         "vite": "8.0.8"
     }


### PR DESCRIPTION
### Security

- **graphql**: Upgraded `webonyx/graphql-php` 15.31.5 → 15.32.3 — patches two high-severity DoS vulnerabilities:
  - Quadratic validation cost in `OverlappingFieldsCanBeMerged` via inline fragments — a crafted GraphQL document using inline fragment spreads could trigger O(n²) validation time before the query complexity limit is applied ([GHSA-fc86-6rv6-2jpm](https://github.com/advisories/GHSA-fc86-6rv6-2jpm)); fixed in `>=15.32.2`
  - Unbounded recursion in the parser — a crafted deeply nested input causes a stack overflow and kills the PHP-FPM worker ([GHSA-r7cg-qjjm-xhqq](https://github.com/advisories/GHSA-r7cg-qjjm-xhqq)); fixed in `>=15.32.3`
- **npm**: Upgraded `axios` 1.15.0 → 1.16.0 — patches 13 high-severity CVEs across four vulnerability classes:
  - **Prototype pollution gadgets** — authentication bypass via `validateStatus` merge strategy ([GHSA-w9j2-pvgh-6h63](https://github.com/advisories/GHSA-w9j2-pvgh-6h63)), invisible JSON response tampering via `parseReviver` ([GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23)), credential injection and request hijacking via HTTP adapter read-side gadgets ([GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj)), header injection ([GHSA-6chq-wfr3-2hj9](https://github.com/advisories/GHSA-6chq-wfr3-2hj9)), XSRF token cross-origin leakage via `withXSRFToken` boolean coercion ([GHSA-xx6v-rp6x-q39c](https://github.com/advisories/GHSA-xx6v-rp6x-q39c)), response tampering / data exfiltration / request hijacking gadget suite ([GHSA-pf86-5x62-jrwf](https://github.com/advisories/GHSA-pf86-5x62-jrwf))
  - **Injection** — null byte injection via reverse-encoding in `AxiosURLSearchParams` ([GHSA-xhjh-pmcv-23jw](https://github.com/advisories/GHSA-xhjh-pmcv-23jw)), CRLF injection in `multipart/form-data` body via unsanitized `blob.type` in `formDataToStream` ([GHSA-445q-vr5w-6q77](https://github.com/advisories/GHSA-445q-vr5w-6q77))
  - **SSRF / proxy bypass** — incomplete `NO_PROXY` fix bypassed via RFC 1122 loopback subnet `127.0.0.0/8` ([GHSA-pmwg-cvhr-8vh7](https://github.com/advisories/GHSA-pmwg-cvhr-8vh7)), `no_proxy` bypass via IP alias allowing SSRF ([GHSA-m7pr-hjqh-92cm](https://github.com/advisories/GHSA-m7pr-hjqh-92cm))
  - **Limit bypass / DoS** — HTTP adapter streamed uploads bypass `maxBodyLength` when `maxRedirects: 0` ([GHSA-5c9x-8gcm-mpgx](https://github.com/advisories/GHSA-5c9x-8gcm-mpgx)), streamed responses bypass `maxContentLength` ([GHSA-vf2m-468p-8v99](https://github.com/advisories/GHSA-vf2m-468p-8v99)), unbounded recursion in `toFormData` causes DoS via deeply nested request data ([GHSA-62hf-57xw-28j9](https://github.com/advisories/GHSA-62hf-57xw-28j9))
- **npm**: Upgraded `postcss` 8.5.9 → 8.5.14 (transitive dependency via `vite`) — patches [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93), a moderate-severity XSS where unescaped `</style>` tags in CSS stringify output could allow script injection in downstream HTML consumers